### PR TITLE
CHECK-158-fastq-int

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             cd ..
             pip install -r src/checkfiles/requirements.txt
             pip install coveralls
-            sudo wget -q --show-progress -O /usr/local/bin/validateFiles http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/validateFiles
+            sudo curl -sS -L -o /usr/local/bin/validateFiles https://raw.github.com/IGVF-DACC/validateFiles/main/validateFiles
             sudo chmod +x /usr/local/bin/validateFiles
             sudo wget https://github.com/EBIvariation/vcf-validator/releases/download/v0.10.0/vcf_assembly_checker_linux
             sudo chmod 755 vcf_assembly_checker_linux

--- a/cdk/tests/snapshots/test_snapshot/test_match_with_snapshot/runner_stack_template.json
+++ b/cdk/tests/snapshots/test_snapshot/test_match_with_snapshot/runner_stack_template.json
@@ -98,7 +98,7 @@
             "Properties": {
                 "Code": {
                     "S3Bucket": "cdk-hnb659fds-assets-testing-testing",
-                    "S3Key": "5c4ad0f5e7eaf22c6b72cad5a4d423c91a66f733144d4771dc4cfb897477fd65.zip"
+                    "S3Key": "65d0ec926cce9f07f6e2827dd67684ff32b2b21cdba451cd02e6108e2a05f174.zip"
                 },
                 "Environment": {
                     "Variables": {

--- a/src/checkfiles/checkfiles.py
+++ b/src/checkfiles/checkfiles.py
@@ -3,6 +3,7 @@ import datetime
 import gzip
 import json
 import logging
+from math import floor
 import multiprocessing
 import os
 import re
@@ -306,8 +307,12 @@ def fastq_get_average_read_length_and_number_of_reads(file_path):
     # b'read_count: 41437223\nminimum_read_length: 28\nmaximum_read_length: 28\nmean_read_length: 28\n' is what output looks like
     for item in output.decode().strip().split('\n'):
         split_item = item.split(': ')
-        # mean might not be an integer to begin with, but schema wants integer so floor it
-        info.update({split_item[0]: round(float(split_item[1]), 2)})
+        # should floor read_count, minimum_read_length and maximum_read_length. Round the mean_read_length
+        if split_item[0] == 'mean_read_length':
+            info.update({split_item[0]: round(float(split_item[1]), 2)})
+        else:
+            info.update({split_item[0]: floor(float(split_item[1]))})
+
     return info
 
 

--- a/src/tests/test_checkfiles.py
+++ b/src/tests/test_checkfiles.py
@@ -42,7 +42,7 @@ def test_fastq_get_average_read_length_and_number_of_reads():
     result = fastq_get_average_read_length_and_number_of_reads(file_path)
     assert result == {
         'read_count': 25,
-        'mean_read_length': 58,
+        'mean_read_length': 58.0,
         'maximum_read_length': 58,
         'minimum_read_length': 58
     }
@@ -392,7 +392,7 @@ def test_main_fastq(mocker):
         'content_md5sum': '1fa9f74aa895c4c938e1712bedf044ec',
         'file_size': 1371,
         'read_count': 25,
-        'mean_read_length': 58,
+        'mean_read_length': 58.0,
         'minimum_read_length': 58,
         'maximum_read_length': 58
     }


### PR DESCRIPTION
1. Keep mean_read_length as a float, floor read_count, maximum_read_length, and minimum_read_length to ints
2. Also solve the bug in [CHECK-151](https://igvf.atlassian.net/browse/CHECK-151) here as well.

[CHECK-151]: https://igvf.atlassian.net/browse/CHECK-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ